### PR TITLE
Music-only cava. +visualizations for ncmpcpp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vimwiki.vim
 fbrun_history
 menuconfig
 fluxbox/.fluxbox/log
+
+*.log

--- a/cava/.config/cava/config
+++ b/cava/.config/cava/config
@@ -49,14 +49,14 @@
 # For alsa 'source' will be the capture device.
 # For fifo 'source' will be the path to fifo-file.
 # For shmem 'source' will be /squeezelite-AA:BB:CC:DD:EE:FF where 'AA:BB:CC:DD:EE:FF' will be squeezelite's MAC address
-method = pulse
+; method = pulse
 ; source = auto
 
 ; method = alsa
 ; source = hw:Loopback,1
 
-; method = fifo
-; source = /tmp/mpd.fifo
+method = fifo
+source = /tmp/mpd.fifo
 
 ; method = shmem
 ; source = /squeezelite-AA:BB:CC:DD:EE:FF

--- a/mpd/.config/mpd/mpd.conf
+++ b/mpd/.config/mpd/mpd.conf
@@ -285,6 +285,15 @@ audio_output {
 ##	server		"remote_server"		# optional
 ##	sink		"remote_server_sink"	# optional
 }
+
+# Fifo needed for ncmcpp visualiser
+audio_output {
+        type            "fifo"
+        name            "my_fifo"
+        path            "/tmp/mpd.fifo"
+        format          "44100:16:2"
+}
+
 #
 # An example of a winmm output (Windows multimedia API).
 #

--- a/ncmcpp/.ncmpcpp/config
+++ b/ncmcpp/.ncmpcpp/config
@@ -1,0 +1,491 @@
+####################################################
+## this is example configuration file, copy it to ##
+## ~/.ncmpcpp/config and set up your preferences  ##
+####################################################
+#
+##### directories ######
+##
+## Directory for storing ncmpcpp related files.
+## Changing it is useful if you want to store
+## everything somewhere else and provide command
+## line setting for alternative location to config
+## file which defines that while launching ncmpcpp.
+##
+#
+ncmpcpp_directory = "~/.ncmpcpp"
+#
+##
+## Directory for storing downloaded lyrics. It
+## defaults to ~/.lyrics since other MPD clients
+## (eg. ncmpc) also use that location.
+##
+#
+#lyrics_directory = "~/.lyrics"
+#
+##### connection settings #####
+#
+## set it in order to make tag editor and renaming files work properly
+#
+mpd_host = "localhost"
+#
+mpd_port = "6600"
+#
+mpd_music_dir = "/mnt/storage/Music"
+#
+#mpd_connection_timeout = "5"
+#
+#mpd_crossfade_time = "5"
+#
+#mpd_communication_mode = "notifications" (polling/notifications)
+#
+##### music visualizer #####
+##
+## Note: In order to make music visualizer work you'll
+## need to use mpd fifo output, whose format parameter
+## has to be set to 44100:16:1 for mono visualization
+## or 44100:16:2 for stereo visualization. Example
+## configuration (it has to be put into mpd.conf):
+##
+## audio_output {
+##        type            "fifo"
+##        name            "My FIFO"
+##        path            "/tmp/mpd.fifo"
+##        format          "44100:16:2"
+## }
+##
+#
+##
+## If you set format to 44100:16:2, make it 'yes'.
+##
+#
+visualizer_in_stereo = "yes"
+#
+visualizer_fifo_path = "/tmp/mpd.fifo"
+#
+##
+## Note: Below parameter is needed for ncmpcpp
+## to determine which output provides data for
+## visualizer and thus allow syncing between
+## visualization and sound as currently there
+## are some problems with it.
+##
+#
+visualizer_output_name = "my_fifo"
+#
+##
+## Note: Below parameter defines how often ncmpcpp
+## has to "synchronize" visualizer and audio outputs.
+## 30 seconds is optimal value, but if you experience
+## synchronization problems, set it to lower value.
+## Keep in mind that sane values start with >=10.
+##
+#
+visualizer_sync_interval = "30"
+#
+##
+## Note: To enable spectrum frequency visualization
+## you need to compile ncmpcpp with fftw3 support.
+##
+#
+visualizer_type = "wave" #(spectrum/wave)
+#
+visualizer_look = "◆│"
+#
+##### system encoding #####
+##
+## ncmpcpp should detect your charset encoding
+## but if it failed to do so, you can specify
+## charset encoding you are using here.
+##
+## Note: You can see whether your ncmpcpp build
+## supports charset detection by checking output
+## of `ncmpcpp --version`.
+##
+## Note: Since MPD uses utf8 by default, setting
+## this option makes sense only if your encoding
+## is different.
+##
+#
+#system_encoding = ""
+#
+##### delays #####
+#
+## delay after playlist highlighting will be disabled (0 = don't disable)
+#
+#playlist_disable_highlight_delay = "5"
+#
+## defines how long various messages are supposed to be visible
+#
+#message_delay_time = "4"
+#
+##### song format #####
+##
+## for song format you can use:
+##
+## %l - length
+## %f - filename
+## %D - directory
+## %a - artist
+## %A - album artist
+## %t - title
+## %b - album
+## %y - year
+## %n - track number (01/12 -> 01)
+## %N - full track info (01/12 -> 01/12)
+## %g - genre
+## %c - composer
+## %p - performer
+## %d - disc
+## %C - comment
+## $R - begin right alignment
+##
+## you can also put them in { } and then it will be displayed
+## only if all requested values are available and/or define alternate
+## value with { }|{ } eg. {%a - %t}|{%f}
+##
+## Note: If you want to set limit on maximal length of a tag, just
+## put the appropriate number between % and character that defines
+## tag type, e.g. to make album take max. 20 terminal cells, use '%20b'.
+##
+## Note: Format that is similar to "%a - %t" (i.e. without any additional
+## braces) is equal to "{%a - %t}", so if one of the tags is missing,
+## you'll get nothing.
+##
+## text can also have different color than the main window has,
+## eg. if you want length to be green, write $3%l$9
+##
+## available values:
+##
+## - 0 - default window color (discards all other colors)
+## - 1 - black
+## - 2 - red
+## - 3 - green
+## - 4 - yellow
+## - 5 - blue
+## - 6 - magenta
+## - 7 - cyan
+## - 8 - white
+## - 9 - end of current color
+##
+## Note: colors can be nested.
+##
+#
+#song_list_format = "{%a - }{%t}|{$8%f$9}$R{$3(%l)$9}"
+#
+#song_status_format = "{{%a{ \"%b\"{ (%y)}} - }{%t}}|{%f}"
+#
+#song_library_format = "{%n - }{%t}|{%f}"
+#
+#tag_editor_album_format = "{(%y) }%b"
+#
+##
+## Note: Below variables are for alternative version of user's interface.
+## Their syntax supports all tags and colors listed above plus some extra
+## markers used for text attributes. They are followed by character '$'.
+## After that you can put:
+##
+## - b - bold text
+## - u - underline text
+## - r - reverse colors
+## - a - use alternative character set
+##
+## If you don't want to use an attribute anymore, just put it again, but
+## this time insert character '/' between '$' and attribute character,
+## e.g. {$b%t$/b}|{$r%f$/r} will display bolded title tag or filename
+## with reversed colors.
+##
+#
+#alternative_header_first_line_format = "$b$1$aqqu$/a$9 {%t}|{%f} $1$atqq$/a$9$/b"
+#
+#alternative_header_second_line_format = "{{$4$b%a$/b$9}{ - $7%b$9}{ ($4%y$9)}}|{%D}"
+#
+##
+## Note: Below variables also supports
+## text attributes listed above.
+##
+#
+#now_playing_prefix = "$b"
+#
+#now_playing_suffix = "$/b"
+#
+#browser_playlist_prefix = "$2playlist$9 "
+#
+#selected_item_prefix = "$6"
+#
+#selected_item_suffix = "$9"
+#
+## colors are not supported for below variable
+#
+#song_window_title_format = "{%a - }{%t}|{%f}"
+#
+##### columns settings #####
+##
+## syntax of song columns list format is "column column etc."
+##
+## - syntax for each column is:
+##
+## (width of column)[column's color]{displayed tag}
+##
+## Note: Width is by default in %, if you want a column to
+## have fixed size, add 'f' after the value, e.g. (10)[white]{a}
+## will be the column that take 10% of screen (so the real column's
+## width will depend on actual screen size), whereas (10f)[white]{a}
+## will take 10 terminal cells, no matter how wide the screen is.
+##
+## - color is optional (if you want the default one, type [])
+##
+## Note: You can give a column additional attributes by putting appropriate
+## character after displayed tag character. Available attributes are:
+##
+## - r - column will be right aligned
+## - E - if tag is empty, empty tag marker won't be displayed
+##
+## You can also:
+##
+## - give a column custom name by putting it after attributes,
+##   separated with character ':', e.g. {lr:Length} gives you
+##   right aligned column of lengths named "Length".
+##
+## - define sequence of tags, that have to be displayed in case
+##   predecessor is empty in a way similar to the one in classic
+##   song format, i.e. using '|' character, e.g. {a|c|p:Owner}
+##   creates column named "Owner" that tries to display artist
+##   tag and then composer and performer if previous ones are
+##   not available.
+##
+#
+#song_columns_list_format = "(7f)[green]{l} (25)[cyan]{a} (40)[]{t|f} (30)[red]{b}"
+#
+##### various settings #####
+#
+##
+## Note: Custom command that will be executed each
+## time song changes. Useful for notifications etc.
+##
+## Attention: It doesn't support song format anymore.
+## Use `ncmpcpp --now-playing SONG_FORMAT` instead.
+##
+#execute_on_song_change = ""
+#
+#playlist_show_remaining_time = "no"
+#
+#playlist_shorten_total_times = "no"
+#
+#playlist_separate_albums = "no"
+#
+#playlist_display_mode = "classic" (classic/columns)
+#
+#browser_display_mode = "classic" (classic/columns)
+#
+#search_engine_display_mode = "classic" (classic/columns)
+#
+#playlist_editor_display_mode = "classic" (classic/columns)
+#
+#discard_colors_if_item_is_selected = "yes"
+#
+#incremental_seeking = "yes"
+#
+#seek_time = "1"
+#
+#autocenter_mode = "no"
+#
+#centered_cursor = "no"
+#
+##
+## Note: You can specify third character which will
+## be used to build 'empty' part of progressbar.
+##
+#progressbar_look = "=>"
+#
+#default_place_to_search_in = "database" (database/playlist)
+#
+#user_interface = "classic" (classic/alternative)
+#
+#media_library_left_column = "a" (possible values: a,y,g,c,p, legend above)
+#
+#default_find_mode = "wrapped" (wrapped/normal)
+#
+#default_space_mode = "add" (add/select)
+#
+#default_tag_editor_left_col = "albums" (albums/dirs)
+#
+#default_tag_editor_pattern = "%n - %t"
+#
+#header_visibility = "yes"
+#
+#statusbar_visibility = "yes"
+#
+#titles_visibility = "yes"
+#
+#header_text_scrolling = "yes"
+#
+#fancy_scrolling = "yes"
+#
+#cyclic_scrolling = "no"
+#
+#lines_scrolled = "2"
+#
+#follow_now_playing_lyrics = "no"
+#
+#fetch_lyrics_for_current_song_in_background = "no"
+#
+#store_lyrics_in_song_dir = "no"
+#
+##
+## Note: If you set this variable, ncmpcpp will try to
+## get info from last.fm in language you set and if it
+## fails, it will fall back to english. Otherwise it will
+## use english the first time.
+##
+## Note: Language has to be expressed as an ISO 639 alpha-2 code.
+##
+#lastfm_preferred_language = ""
+#
+#ncmpc_like_songs_adding = "no" (enabled - add/remove, disabled - always add)
+#
+#show_hidden_files_in_local_browser = "no"
+#
+#display_screens_numbers_on_start = "yes"
+#
+##
+## How shall key_screen_switcher work?
+##
+## - "previous" - switch between current and last used screen
+## - "sequence: 2 -> 9 -> 5" - switch between given sequence of screens.
+##
+## Screen numbers you can use after 'sequence' keyword are:
+##
+## - 1 - help
+## - 2 - playlist
+## - 3 - browser
+## - 4 - search engine
+## - 5 - media library
+## - 6 - playlist editor
+## - 7 - tag editor
+## - 8 - outputs
+## - 9 - visualizer
+## - 10 - clock
+##
+## As you can see, above example will switch between
+## playlist, visualizer and media library screens.
+##
+#screen_switcher_mode = "sequence: 2 -> 3"
+#
+##
+## Default width of locked screen (in %).
+## Acceptable values are from 20 to 80.
+##
+#
+#locked_screen_width_part = "50"
+#
+#ask_for_locked_screen_width_part = "yes"
+#
+##
+## Note: You can define startup screen for ncmpcpp
+## by choosing screen number from the list above.
+##
+#startup_screen = "2"
+#
+#jump_to_now_playing_song_at_start = "yes"
+#
+#ask_before_clearing_main_playlist = "no"
+#
+#clock_display_seconds = "no"
+#
+#display_volume_level = "yes"
+#
+#display_bitrate = "no"
+#
+#display_remaining_time = "no"
+#
+#regular_expressions = "basic" (basic/extended)
+#
+##
+## Note: If below is enabled, ncmpcpp will ignore leading
+## "The" word while sorting items in browser, tags in
+## media library, etc.
+##
+#ignore_leading_the = "no"
+#
+#block_search_constraints_change_if_items_found = "yes"
+#
+#mouse_support = "yes"
+#
+#mouse_list_scroll_whole_page = "yes"
+#
+#empty_tag_marker = "<empty>"
+#
+#tag_editor_extended_numeration = "no"
+#
+#media_library_display_date = "yes"
+#
+#media_library_display_empty_tag = "yes"
+#
+#media_library_disable_two_column_mode = "no"
+#
+#enable_window_title = "yes"
+#
+##
+## Note: You can choose default search mode for search
+## engine. Available modes are:
+##
+## - 1 - use mpd built-in searching (no regexes, pattern matching)
+## - 2 - use ncmpcpp searching (pattern matching with support for regexes,
+##       but if your mpd is on a remote machine, downloading big database
+##       to process it can take a while
+## - 3 - match only exact values (this mode uses mpd function for searching
+##       in database and local one for searching in current playlist)
+##
+#
+#search_engine_default_search_mode = "1"
+#
+##
+## Note: Below variables can allow you to physically
+## remove files and directories from your hdd using
+## ncmpcpp's browser screen.
+##
+#
+#allow_physical_files_deletion = "no"
+#
+#allow_physical_directories_deletion = "no"
+#
+#external_editor = ""
+#
+#use_console_editor = "no" (set to yes, if your editor is console app)
+#
+##### colors definitions #####
+#
+#colors_enabled = "yes"
+#
+#empty_tag_color = "cyan"
+#
+#header_window_color = "default"
+#
+#volume_color = "default"
+#
+#state_line_color = "default"
+#
+#state_flags_color = "default"
+#
+#main_window_color = "yellow"
+#
+#color1 = "white"
+#
+#color2 = "green"
+#
+#main_window_highlight_color = "yellow"
+#
+#progressbar_color = "default"
+#
+#statusbar_color = "default"
+#
+#alternative_ui_separator_color = "black"
+#
+#active_column_color = "red"
+#
+#visualizer_color = "yellow"
+#
+#window_border_color = "green"
+#
+#active_window_border = "red"
+#


### PR DESCRIPTION
Added visualizations for ncmpcpp.
Changed cava so that it only visualizes music from MPD. This was
accomplished by using fifo output (needed for ncmpcpp) instead of pulse
output (which is output for the whole system).